### PR TITLE
Honor object class use-flags when applying data file modifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "w3xdata",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "w3xdata",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "mdx-m3-viewer-th": "^5.13.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w3xdata",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Exact data from Warcraft III maps",
   "author": "verit",
   "license": "MIT",

--- a/src/mapItemSpecs.test.ts
+++ b/src/mapItemSpecs.test.ts
@@ -30,3 +30,22 @@ it("applies skin overrides on top of the main w3t", async () => {
     art: { Art: "ReplaceableTextures\\CommandButtons\\BTNThoriumMelee.tga" },
   });
 });
+
+it("honors item use-flags, ignoring fields that don't apply to items", async () => {
+  const [w3t, skin] = await Promise.all([
+    readFile("src/test/data/war3map.w3t"),
+    readFile("src/test/data/war3mapSkin.w3t"),
+  ]);
+  const specs = mapItemSpecs(w3t, skin);
+
+  // I000's icon override uses iico (the item-icon field, useItem=1), so it
+  // applies. I003 (a custom item based on ches) instead has a uico override,
+  // the unit-icon field (useItem=0); the engine ignores it, so I003 keeps its
+  // base cheese icon.
+  expect(specs.I000.art).toMatchObject({
+    Art: "ReplaceableTextures\\CommandButtons\\BTNThoriumMelee.tga",
+  });
+  expect(specs.I003.art).toMatchObject({
+    Art: "ReplaceableTextures\\CommandButtons\\BTNCheese.blp",
+  });
+});

--- a/src/mapItemSpecs.ts
+++ b/src/mapItemSpecs.ts
@@ -9,7 +9,7 @@ export const mapItemSpecs = (
   w3tSkin?: W3uW3tInput,
 ): Record<string, ItemSpec> => {
   const items = structuredClone(baseItems);
-  applyDataFile(items, w3t);
-  if (w3tSkin) applyDataFile(items, w3tSkin);
+  applyDataFile(items, w3t, "item");
+  if (w3tSkin) applyDataFile(items, w3tSkin, "item");
   return items;
 };

--- a/src/mapUnitSpecs.test.ts
+++ b/src/mapUnitSpecs.test.ts
@@ -34,3 +34,16 @@ it("applies skin overrides on top of the main w3u", async () => {
     },
   });
 });
+
+it("applies unit-valid art fields like uico", async () => {
+  const [w3u, skin] = await Promise.all([
+    readFile("src/test/data/war3map.w3u"),
+    readFile("src/test/data/war3mapSkin.w3u"),
+  ]);
+  const specs = mapUnitSpecs(w3u, skin);
+
+  // uico is the unit-icon field (useUnit=1), so unlike on items it applies.
+  expect(specs.hC06.art).toMatchObject({
+    Art: "ReplaceableTextures\\CommandButtons\\BTNHumanBarracks.blp",
+  });
+});

--- a/src/mapUnitSpecs.ts
+++ b/src/mapUnitSpecs.ts
@@ -9,7 +9,7 @@ export const mapUnitSpecs = (
   w3uSkin?: W3uW3tInput,
 ): Record<string, UnitSpec> => {
   const units = structuredClone(baseUnits);
-  applyDataFile(units, w3u);
-  if (w3uSkin) applyDataFile(units, w3uSkin);
+  applyDataFile(units, w3u, "unit");
+  if (w3uSkin) applyDataFile(units, w3uSkin, "unit");
   return units;
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import { parsers } from "mdx-m3-viewer-th";
 import type Modification from "mdx-m3-viewer-th/dist/cjs/parsers/w3x/w3u/modification";
-import type { ItemSpec, UnitSpec } from "wc3data";
+import type { ItemSpec, TypeSpec, UnitSpec } from "wc3data";
 import { castValue, types } from "wc3data";
 
 const War3MapW3uFile = parsers.w3x.w3u.File;
@@ -8,26 +8,41 @@ export type W3uW3tInput = Parameters<
   InstanceType<typeof War3MapW3uFile>["load"]
 >[0];
 
+/** The object class a data file describes, used to gate field modifications. */
+export type ObjectClass = "item" | "unit";
+
+// Each `types` entry carries use-flags marking which object classes a field
+// applies to. The WC3 engine silently ignores modifications whose field does
+// not apply to the object (e.g. a unit-icon `uico` override on an item), so we
+// honor the same flags. The unit file mixes units, heroes and buildings, so a
+// modification on a "unit" qualifies if any of those flags is set.
+const classUseFlags = {
+  item: ["useItem"],
+  unit: ["useUnit", "useHero", "useBuilding"],
+} as const satisfies Record<ObjectClass, readonly (keyof TypeSpec)[]>;
+
 export const applyDataFile = <T extends UnitSpec | ItemSpec>(
   specs: Record<string, T>,
   input: W3uW3tInput,
+  objectClass: ObjectClass,
 ): void => {
   const file = new War3MapW3uFile();
   file.load(input);
 
   for (const { newId, oldId, modifications } of file.customTable.objects) {
     if (!specs[newId]) specs[newId] = structuredClone(specs[oldId]);
-    applyModifications(specs[newId], modifications);
+    applyModifications(specs[newId], modifications, objectClass);
   }
 
   for (const { oldId, modifications } of file.originalTable.objects) {
-    applyModifications(specs[oldId], modifications);
+    applyModifications(specs[oldId], modifications, objectClass);
   }
 };
 
 export const applyModifications = (
   spec: UnitSpec | ItemSpec,
   modifications: Modification[],
+  objectClass: ObjectClass,
 ): void => {
   // deno-lint-ignore no-explicit-any
   const unsafeSpec: any = spec;
@@ -37,6 +52,12 @@ export const applyModifications = (
       console.warn(`Skipping modification ${modification.id}`);
       continue;
     }
+
+    // Skip fields that don't apply to this object class, matching the engine.
+    // (Not logged: real map data routinely carries non-applicable fields, e.g.
+    // unit-only fields stored alongside items in skin files, so warning here
+    // would be very noisy.)
+    if (!classUseFlags[objectClass].some((flag) => type[flag])) continue;
 
     const category = type.category;
     if (category) {


### PR DESCRIPTION
## Summary
This PR adds support for filtering data file modifications based on object class use-flags, matching the behavior of the WC3 engine. The engine silently ignores modifications whose fields don't apply to the target object type (e.g., unit-only fields on items), and this implementation now does the same.

## Key Changes
- Added `ObjectClass` type to distinguish between "item" and "unit" object types
- Introduced `classUseFlags` mapping that defines which field use-flags apply to each object class
  - Items: only fields with `useItem` flag
  - Units: fields with `useUnit`, `useHero`, or `useBuilding` flags
- Updated `applyDataFile()` and `applyModifications()` to accept an `objectClass` parameter
- Added filtering logic to skip modifications whose fields don't apply to the target object class
- Updated `mapItemSpecs()` and `mapUnitSpecs()` to pass the appropriate object class when applying modifications

## Implementation Details
- The use-flag checking is performed silently without logging, as real map data routinely carries non-applicable fields (e.g., unit-only fields in item skin files), which would otherwise produce excessive warnings
- The implementation leverages the existing `TypeSpec` type from `wc3data` which already carries the use-flag information
- Added comprehensive test coverage for both item and unit specifications to verify the filtering behavior works correctly

https://claude.ai/code/session_01SqWdrcE81WQtZFKGeVrWiq